### PR TITLE
plugin for openbmc rpower command

### DIFF
--- a/xcat3/common/exception.py
+++ b/xcat3/common/exception.py
@@ -280,3 +280,7 @@ class NicNotFound(NotFound):
 
 class PluginNotFound(NotFound):
     _msg_fmt = _("plugin for %(name)s could not been loaded.")
+
+
+class ExceptionFromRestRsp(XCAT3Exception):
+    _msg_fmt = _("%(exception)s.")

--- a/xcat3/common/rest.py
+++ b/xcat3/common/rest.py
@@ -1,0 +1,61 @@
+from oslo_log import log as logging
+from xcat3.common import exception
+
+import requests
+import json
+
+LOG = logging.getLogger(__name__)
+
+class RestSession :
+
+    def __init__(self) :
+        self.session = requests.Session()
+
+    def _request_log(self, method, url, headers, data) :
+        log_string = ['curl -k']
+        log_string.append(' -X %s' % method)
+        log_string.append(' -H %s' % headers)
+        log_string.append(" '%s'" % url)
+
+        if data :
+            log_string.append('-d %s' % data)
+
+        LOG.info("REQ: %s" % "".join(log_string))
+
+    def _rspcheck(self, rsp) :
+        if rsp.text and rsp.status_code != 400 :
+            try :
+                body = json.loads(rsp.text)
+            except ValueError :
+                body = None
+        else :
+            body = None
+
+        LOG.info("RESP: [%(status)s]\nRESP URL: %(url)s\nRESP BODY: %(text)s\n",
+                {'status': rsp.status_code, 'url': rsp.url, 'text': json.dumps(body)})
+
+        if rsp.status_code >= 400 :
+            raise exception.ExceptionFromRestRsp(exception=rsp.reason)
+
+    def request (self, method, url, headers, in_data) :
+        if in_data :
+            data = json.dumps(in_data)
+        else :
+            data = ''
+
+        self._request_log(method, url, headers, data)
+
+        try :
+            response = self.session.request(method, url,
+                                            data=data,
+                                            headers=headers,
+                                            verify = False)
+
+        except requests.exceptions.ConnectionError as e :
+            raise requests.exceptions.ConnectionError('Unable to connect to server')
+
+        self._rspcheck(response)
+
+        if method == 'GET' :
+            return response.json()
+

--- a/xcat3/common/states.py
+++ b/xcat3/common/states.py
@@ -58,3 +58,13 @@ SOFT_POWER_OFF = 'soft power off'
 FAIL = 'failed'
 SUCCESS = 'ok'
 DELETED = 'deleted'
+
+################
+# Power command
+################
+
+POWER_COMMAND_ON = 'on'
+POWER_COMMAND_OFF = 'off'
+POWER_COMMAND_BOOT = 'boot'
+POWER_COMMAND_RESET = 'reset'
+

--- a/xcat3/plugins/control/openbmc.py
+++ b/xcat3/plugins/control/openbmc.py
@@ -1,0 +1,88 @@
+from oslo_log import log
+from xcat3.plugins.control import base
+from xcat3.common import exception
+from xcat3.common import states
+from xcat3.common import rest
+
+import pdb
+
+LOG = log.getLogger(__name__)
+
+url_dict  = {"set_power_state" : "/xyz/openbmc_project/state/host0/attr/RequestedHostTransition",
+             "get_power_state"  : "/xyz/openbmc_project/state/host0" }
+
+data_dict = {states.POWER_COMMAND_ON   : "xyz.openbmc_project.State.Host.Transition.On",
+             states.POWER_COMMAND_OFF  : "xyz.openbmc_project.State.Host.Transition.Off",
+             states.POWER_COMMAND_RESET: "xyz.openbmc_project.State.Host.Transition.Reboot"}
+
+class OPENBMCPlugin(base.ControlInterface) :
+
+    headers = {'Content-Type': 'application/json'}
+
+    def validate(self, node) :
+        bmc = node.control_info.get('bmc_address')
+        bmcusername = node.control_info.get('bmc_username')
+        bmcpassword = node.control_info.get('bmc_password')
+        if not bmc :
+            raise exception.MissingParameterValue(
+                _("OPENBMC address was not specified."))
+        if not bmcusername :
+            raise exception.MissingParameterValue(
+                _("OPENBMC username was not specified."))
+        if not bmcpassword :
+            raise exception.MissingParameterValue(
+                _("OPENBMC password was not specified."))
+
+    def _login(self, node) :
+        login_url = 'https://' + node.control_info['bmc_address'] + '/login'
+        login_data = { "data": [ node.control_info['bmc_username'], node.control_info['bmc_password'] ] }
+        client = rest.RestSession()
+        client.request('POST', login_url, OPENBMCPlugin.headers, login_data)
+
+        return client
+
+    def _get_power_state(self, client, node) :
+        request_url = 'https://' + node.control_info['bmc_address'] + url_dict['get_power_state']
+        rpower_data = client.request('GET', request_url, OPENBMCPlugin.headers, '')
+        rpower_state = rpower_data['data']['CurrentHostState']
+
+        return rpower_state
+
+    def get_power_state(self, node) :
+        LOG.info("RPC get_power_state called for nodes %(node)s. ",
+                 {'node': node.name})
+
+        client = self._login(node)
+        rpower_state = self._get_power_state(client, node)
+
+        return rpower_state
+
+    def set_power_state(self, node, power_state) :
+        pdb.set_trace
+
+        LOG.info("RPC set_power_state called for nodes %(node)s. "
+                 "The desired new state is %(target)s.",
+                 {'node': node.name, 'target': power_state})
+
+        client = self._login(node)
+
+        if power_state == states.POWER_COMMAND_BOOT :
+            rpower_status = self._get_power_state(client, node)
+            if rpower_status == 'xyz.openbmc_project.State.Host.HostState.Off' :
+                request_data = { "data": data_dict[states.POWER_COMMAND_ON] }
+            else :
+                request_data = { "data": data_dict[states.POWER_COMMAND_RESET] }
+        elif power_state == states.POWER_COMMAND_ON :
+            request_data = { "data": data_dict[states.POWER_COMMAND_ON] }
+        elif power_state == states.POWER_COMMAND_OFF :
+            request_data = { "data": data_dict[states.POWER_COMMAND_OFF] }
+        elif power_state == states.POWER_COMMAND_RESET :
+            request_data = { "data": data_dict[states.POWER_COMMAND_RESET] }
+
+        request_url = 'https://' + node.control_info['bmc_address'] + url_dict['set_power_state']
+        request_rsp = client.request('PUT', request_url, OPENBMCPlugin.headers, request_data)
+
+    def reboot(self, node) :
+        pass
+
+

--- a/xcat3/plugins/mapping.py
+++ b/xcat3/plugins/mapping.py
@@ -1,12 +1,13 @@
 from oslo_log import log
 from xcat3.common import exception
 from xcat3.plugins.control import ipmi
+from xcat3.plugins.control import openbmc
 
 LOG = log.getLogger(__name__)
 
 plugin_map = dict()
 plugin_map['ipmi'] = ipmi.IPMIPlugin()
-
+plugin_map['openbmc'] = openbmc.OPENBMCPlugin()
 
 def get_plugin(node):
     control_plugin = plugin_map.get(node.mgt)


### PR DESCRIPTION
Support commands:

rpower <node> on/off/reset/state/boot
```
#curl -XGET 'http://localhost:3010/v1/nodes/openbmc_test' -H Content-Type:application/json  | jq .
{
  "nics_info": {
    "nics": []
  },
  "type": null,
  "console_info": {},
  "name": "openbmc_test",
  "arch": null,
  "created_at": "2017-03-23T08:24:26+00:00",
  "updated_at": "2017-03-27T05:33:27+00:00",
  "control_info": {
    "bmcusername": "root",
    "bmcpassword": "0penBmc",
    "bmc": "9.3.185.161"
  },
  "mgt": "openbmc",
  "reservation": null
}
```

```
# curl -XGET 'http://localhost:3010/v1/nodes/power' -H Content-Type:application/json -d '{"nodes": [{"name": "openbmc_test"}]}' | jq .
{
  "nodes": {
    "openbmc_test": "xyz.openbmc_project.State.Host.HostState.Quiesced"
  }
}
```

```
# curl -XPUT 'http://localhost:3010/v1/nodes/states/power?target=on' -H Content-Type:application/json -d '{"nodes":[{"name":"openbmc_test"}]}' | jq .
{
  "nodes": {
    "openbmc_test": "ok"
  }
}
```

